### PR TITLE
Get token via http head and return on failure

### DIFF
--- a/fhemcl.sh
+++ b/fhemcl.sh
@@ -32,8 +32,11 @@ else
     hosturl=$1
 fi
 
-# get Token 
-token=$(curl -s -D - "$hosturl/fhem?XHR=1" | awk '/X-FHEM-csrfToken/{print $2}')
+# get Token via http Head request
+token=$(curl -Is "$hosturl/fhem?XHR=1" | awk '/X-FHEM-csrfToken/{print $2}')
+if [ -z "${token}" ]; then 
+	exit 1
+fi
 
 # reading FHEM command, from Pipe, File or Arguments 
 # Check to see if a pipe exists on stdin.

--- a/fhemcl.sh
+++ b/fhemcl.sh
@@ -32,9 +32,15 @@ else
     hosturl=$1
 fi
 
-# get Token via http Head request
-token=$(curl -Is "$hosturl/fhem?XHR=1" | awk '/X-FHEM-csrfToken/{print $2}')
-if [ -z "${token}" ]; then 
+# get Token and Status
+token=;PROTO=;STATUS=;MSG=
+while IFS=':' read key value; do
+    case "$key" in
+        X-FHEM-csrfToken) token="$value"      ;;
+        HTTP*) read PROTO STATUS MSG <<< $key ;;
+     esac
+done < <(curl -s -D - "$hosturl/fhem?XHR=1")
+if [ -z "${STATUS}" ]; then 
 	exit 1
 fi
 


### PR DESCRIPTION
Get the error code via http head request and return with exitcode 1 if there was an error or no csrf token was provided